### PR TITLE
Run unittests on travis server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+        - "2.7"
+
+install: "pip install -r requirements.txt"
+script:  'python -m unittest discover -s graphwalker/test -p "*_test.py"'
+sudo: false
+cache: pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-[dot]pydot
-[cli]docopt
+pydot >= 1.0.2
+docopt >= 0.6.2


### PR DESCRIPTION
Travis is a continuous integration service that can be uses for open source projects located on github. They need a .travis.yml file that contains the commands to be executed after each push in the (master)
This branch contains that travis file. If the upstream project also enables the travis service, then each commit can be tested automatically.