### PR TITLE
Ensure the python of the PATH is used

### DIFF
--- a/bin/graphwalker
+++ b/bin/graphwalker
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2013 Spotify AB
 from graphwalker import cli

--- a/graphwalker/cli.py
+++ b/graphwalker/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2013 Spotify AB
 import time


### PR DESCRIPTION
If you have several versions of python installed for example via a virtualenv environment, /usr/bin/env will
ensure the interpreter is used on your environments $PATH.
